### PR TITLE
Remove duplicate l10n_ch_postal field on bank account

### DIFF
--- a/l10n_ch_base_bank/views/bank.xml
+++ b/l10n_ch_base_bank/views/bank.xml
@@ -57,16 +57,5 @@
                 </field>
             </field>
         </record>
-        <record model="ir.ui.view" id="add_postal_on_res_partner_bank">
-            <field name="name">Add postal on res partner bank</field>
-            <field name="model">res.partner.bank</field>
-            <field name="inherit_id" ref="base.view_partner_bank_form" />
-            <field name="arch" type="xml">
-                <field name="bank_id" position="after">
-                    <!-- l10n_ch_isr_subscription_number added in l10n_ch_payment_slip -->
-                    <field name="l10n_ch_postal" />
-                </field>
-            </field>
-        </record>
     </data>
 </odoo>


### PR DESCRIPTION
The l10n_ch_postal field is already present in the view:

https://github.com/odoo/odoo/blob/13.0/addons/l10n_ch/views/res_bank_view.xml#L10-L12

(have been added in https://github.com/odoo/odoo/commit/b49437371cec19197b9f4de391e26f9692d437c2 )